### PR TITLE
클래스 책임 분리

### DIFF
--- a/src/main/java/com/kurt/practice/springbootsecuritypractice/config/UserManagementConfig.java
+++ b/src/main/java/com/kurt/practice/springbootsecuritypractice/config/UserManagementConfig.java
@@ -1,29 +1,17 @@
 package com.kurt.practice.springbootsecuritypractice.config;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
-import org.springframework.security.web.SecurityFilterChain;
 
-public class SecurityConfig {
-
-    @Bean
-    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests(authz ->
-                        authz.anyRequest().authenticated())
-                .httpBasic();
-
-        return http.build();
-    }
+public class UserManagementConfig {
 
     @Bean
     public UserDetailsService userDetailsService() {
-         UserDetailsService userDetailsService = new InMemoryUserDetailsManager();
+        UserDetailsService userDetailsService = new InMemoryUserDetailsManager();
 
         User user = (User) User.withUsername("kurt")
                 .password("12345")
@@ -39,6 +27,5 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return NoOpPasswordEncoder.getInstance();
     }
-
 
 }

--- a/src/main/java/com/kurt/practice/springbootsecuritypractice/config/WebAuthorizaionConfig.java
+++ b/src/main/java/com/kurt/practice/springbootsecuritypractice/config/WebAuthorizaionConfig.java
@@ -1,0 +1,18 @@
+package com.kurt.practice.springbootsecuritypractice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+public class WebAuthorizaionConfig {
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authz ->
+                        authz.anyRequest().authenticated())
+                .httpBasic();
+
+        return http.build();
+    }
+}

--- a/src/test/java/com/kurt/practice/springbootsecuritypractice/controller/HelloControllerTest.java
+++ b/src/test/java/com/kurt/practice/springbootsecuritypractice/controller/HelloControllerTest.java
@@ -1,21 +1,20 @@
 package com.kurt.practice.springbootsecuritypractice.controller;
 
-import com.kurt.practice.springbootsecuritypractice.config.SecurityConfig;
+import com.kurt.practice.springbootsecuritypractice.config.UserManagementConfig;
+import com.kurt.practice.springbootsecuritypractice.config.WebAuthorizaionConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Import(SecurityConfig.class)
+@Import({UserManagementConfig.class, WebAuthorizaionConfig.class})
 @WebMvcTest(HelloController.class)
 class HelloControllerTest {
 


### PR DESCRIPTION
항상 한 클래스가 하나의 책임을 맡도록 하는 것이 바람직하다.
- 권한부여
- 사용자 관리  로 구성을 분리했다.
그리고 그에 맞게 테스트 코드 @Improt를 수정했다.